### PR TITLE
ci: add project build on ci pipeline

### DIFF
--- a/.github/workflows/run-tests-dev.yaml
+++ b/.github/workflows/run-tests-dev.yaml
@@ -74,12 +74,13 @@ jobs:
         run: npm ci
         working-directory: frontend/nextjs-app 
 
-      - name: Build Frontend
-        run: npm run build
-        working-directory: frontend/nextjs-app
+      # - name: Build Frontend
+      #   run: npm run build
+      #   working-directory: frontend/nextjs-app
 
       - name: Start Frontend
-        run: npm run start &
+        # run: npm run start &
+        run: npm run dev &
         working-directory: frontend/nextjs-app
 
       - name: Run end-to-end tests on Cypress

--- a/.github/workflows/run-tests-dev.yaml
+++ b/.github/workflows/run-tests-dev.yaml
@@ -57,8 +57,12 @@ jobs:
         run: npx prisma db seed
         working-directory: backend
 
+      - name: Build Backend
+        run: npm run build
+        working-directory: backend
+
       - name: Starts Backend
-        run: npm run start &
+        run: npm run start:prod &
         working-directory: backend
 
       - name: Checkout Frontend
@@ -71,7 +75,11 @@ jobs:
         working-directory: frontend/nextjs-app 
 
       - name: Build Frontend
-        run: npm run dev &
+        run: npm run build
+        working-directory: frontend/nextjs-app
+
+      - name: Start Frontend
+        run: npm run start &
         working-directory: frontend/nextjs-app
 
       - name: Run end-to-end tests on Cypress
@@ -81,3 +89,18 @@ jobs:
           command: npm run cypress
           wait-on: 'http://localhost:3001'
           working-directory: backend
+
+  build-dockerimage:
+    name: 'Builds Docker Image'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Builds Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: false
+        tags: |
+          rodrigomolter/docunder-api:latest

--- a/.github/workflows/run-tests-main.yaml
+++ b/.github/workflows/run-tests-main.yaml
@@ -74,12 +74,13 @@ jobs:
         run: npm ci
         working-directory: frontend/nextjs-app 
 
-      - name: Build Frontend
-        run: npm run build
-        working-directory: frontend/nextjs-app
+      # - name: Build Frontend
+      #   run: npm run build
+      #   working-directory: frontend/nextjs-app
 
       - name: Start Frontend
-        run: npm run start &
+        # run: npm run start &
+        run: npm run dev &
         working-directory: frontend/nextjs-app
 
       - name: Run end-to-end tests on Cypress

--- a/.github/workflows/run-tests-main.yaml
+++ b/.github/workflows/run-tests-main.yaml
@@ -57,8 +57,12 @@ jobs:
         run: npx prisma db seed
         working-directory: backend
 
+      - name: Build Backend
+        run: npm run build
+        working-directory: backend
+
       - name: Starts Backend
-        run: npm run start &
+        run: npm run start:prod &
         working-directory: backend
 
       - name: Checkout Frontend
@@ -71,7 +75,11 @@ jobs:
         working-directory: frontend/nextjs-app 
 
       - name: Build Frontend
-        run: npm run dev &
+        run: npm run build
+        working-directory: frontend/nextjs-app
+
+      - name: Start Frontend
+        run: npm run start &
         working-directory: frontend/nextjs-app
 
       - name: Run end-to-end tests on Cypress
@@ -81,3 +89,18 @@ jobs:
           command: npm run cypress
           wait-on: 'http://localhost:3001'
           working-directory: backend
+
+  build-dockerimage:
+    name: 'Builds Docker Image'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Builds Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: false
+        tags: |
+          rodrigomolter/docunder-api:latest


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Chore (documentation, packages, or tests updates, nothing that affect the final user directly)
- [ ] Release (new version of the application - only for production)

## Description
- Adding to run the `npm run build` before the test executions in the backend
- Building docker image in paralel to check for inconsistences.


## Dependencies

This pull request has a dependency on the following others:

- [#43 ci: add project build on ci pipeline](https://github.com/Organizacao-Docunder/App/pull/43)

