### PR TITLE
Fix/show hide password icon

### DIFF
--- a/nextjs-app/src/app/recover-password/page.tsx
+++ b/nextjs-app/src/app/recover-password/page.tsx
@@ -7,8 +7,13 @@ import check from "../../assets/icons/check.svg"
 import { useRouter } from "next/navigation";
 import Background from "@/components/Background";
 
+import eyesOpenIcon from '@/assets/icons/eyes_open.png'
+import eyesClosedIcon from '@/assets/icons/eyes_closed.png'
+
 export default function RecoverPasswordPage() {
   const [email, setEmail] = useState("")
+  const [showPassword, setShowPassword] = useState('password');
+  const [showMatchPassword, setShowMatchPassword] = useState('password');
   const [questionAndAnswer, setQuestionAndAnswer] = useState({
     questionId: 0,
     answer: ""
@@ -117,32 +122,58 @@ export default function RecoverPasswordPage() {
                 <h1 className={`mb-12 text-primary-1 font-weight-600`}>Recuperar senha</h1>
                 <div className="flex flex-col w-full max-w-sm">
                   <p className="text-neutral-2 py-1">Nova senha</p>
-                  <input
-                    placeholder="Insira sua senha"
-                    required
-                    type="password"
-                    name="password"
-                    id="password"
-                    value={newPassword.password}
-                    onChange={(e) => onChange(e, newPassword, setNewPassword)}
-                    className={`w-full p-3 border border-solid rounded text-neutral-2 ${response.cause === 'password' ? 'border-red-500' : 'border-primary-1'}`}
-                  />
+                  <div className={`flex border border-solid rounded overflow-hidden focus-within:border-black ${response.cause === 'password' ? 'border-red-500' : 'border-primary-1'}`}>
+                    <input
+                      placeholder="Insira sua senha"
+                      required
+                      type={showPassword}
+                      name="password"
+                      id="password"
+                      value={newPassword.password}
+                      onChange={(e) => onChange(e, newPassword, setNewPassword)}
+                      className="w-full p-3 text-neutral-2 focus:outline-none"
+                    />
+                    <button className="bg-white px-3" onClick={(e) => {
+                      e.preventDefault()
+                      setShowPassword(showPassword === 'password' ? 'text' : 'password')
+                    }}>
+                      <Image
+                        src={showPassword === 'password' ? eyesOpenIcon : eyesClosedIcon}
+                        alt="password icon"
+                        width={24}
+                        height={24}
+                      />
+                    </button>
+                  </div>
                   <span className="h-4 pt-1 w-full flex justify-end items-center">
                     <p className="text-red-500 text-sm">
                       {response.cause === "password" && response.message}
                     </p>
                   </span>
                   <p className="text-neutral-2 py-1">Confirmar senha</p>
-                  <input
-                    placeholder="Insira novamente sua senha"
-                    required
-                    type="password"
-                    name="matchPassword"
-                    id="matchPassword"
-                    value={newPassword.matchPassword}
-                    onChange={(e) => onChange(e, newPassword, setNewPassword)}
-                    className={`w-full p-3 border border-solid rounded text-neutral-2 ${response.cause === 'match password' ? 'border-red-500' : 'border-primary-1'}`}
-                  />
+                  <div className={`flex border border-solid rounded overflow-hidden focus-within:border-black ${response.cause === 'password' ? 'border-red-500' : 'border-primary-1'}`}>
+                    <input
+                      placeholder="Insira novamente sua senha"
+                      required
+                      type={showMatchPassword}
+                      name="matchPassword"
+                      id="matchPassword"
+                      value={newPassword.matchPassword}
+                      onChange={(e) => onChange(e, newPassword, setNewPassword)}
+                      className="w-full p-3 text-neutral-2 focus:outline-none"
+                    />
+                    <button className="bg-white px-3" onClick={(e) => {
+                      e.preventDefault()
+                      setShowMatchPassword(showMatchPassword === 'password' ? 'text' : 'password')
+                    }}>
+                      <Image
+                        src={showMatchPassword === 'password' ? eyesOpenIcon : eyesClosedIcon}
+                        alt="password icon"
+                        width={24}
+                        height={24}
+                      />
+                    </button>
+                  </div>
                   <span className="h-4 pt-1 w-full flex justify-end items-center">
                     <p className="text-red-500 text-sm">
                       {response.cause === "match password" && response.message}

--- a/nextjs-app/src/app/signup/page.tsx
+++ b/nextjs-app/src/app/signup/page.tsx
@@ -106,9 +106,9 @@ export default function SignupPage() {
       setIsModalSecretAnswersOpen(true)
     }
   }
-  
+
   const router = useRouter();
-  
+
   async function onSubmit() {
     const result: any = await signup(firstForm, secondForm);
     setResponse(result)
@@ -187,7 +187,7 @@ export default function SignupPage() {
                       setShowPassword(showPassword === 'password' ? 'text' : 'password')
                     }}>
                       <Image
-                        src={showPassword === 'password' ? eyesClosedIcon : eyesOpenIcon}
+                        src={showPassword === 'password' ? eyesOpenIcon : eyesClosedIcon}
                         alt="password icon"
                         width={24}
                         height={24}
@@ -218,7 +218,7 @@ export default function SignupPage() {
                       setShowMatchPassword(showMatchPassword === 'password' ? 'text' : 'password')
                     }}>
                       <Image
-                        src={showMatchPassword === 'password' ? eyesClosedIcon : eyesOpenIcon}
+                        src={showMatchPassword === 'password' ? eyesOpenIcon : eyesClosedIcon}
                         alt="password icon"
                         width={24}
                         height={24}


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Chore (documentation, packages, or tests updates, nothing that affect the final user directly)
- [ ] Release (new version of the application - only for production)

## Description

FIX: The icons on the new registration page were inverted in the preview
 - fix icon display
 
FIX: add toggle for password visibility in recover password page

- Introduced `eyesOpenIcon` and `eyesClosedIcon` for visual representation of password visibility toggle.
- Added `showPassword` and `showMatchPassword` states to manage the password field visibility.

## Tasks

- #SCRUM-73 -  Ícone Ocultar/ Mostra Senha. Não segue o Padrão Convencional na página Novo Cadastro
- #SCRUM-51 -  Na página de recuperar senha não há botão de ocultar/mostrar senha